### PR TITLE
feat: add option for ignoring missing mapped types

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -175,7 +175,7 @@ func (c *Connection) TypeMappingHandler(handler HandlerFunc) HandlerFunc {
 		routingKey := headers["routing-key"].(string)
 		typ, exists := c.keyToType[routingKey]
 		if !exists {
-			return nil, fmt.Errorf("no mapped type found for routing key '%s'", routingKey)
+			return nil, nil
 		}
 		body := []byte(*msg.(*json.RawMessage))
 		message, err := c.parseMessage(body, typ)

--- a/connection_test.go
+++ b/connection_test.go
@@ -563,7 +563,7 @@ func TestConnection_TypeMappingHandler(t *testing.T) {
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
-			name:   "no mapped type",
+			name:   "no mapped type, ignored",
 			fields: fields{},
 			args: args{
 				msg: []byte(`{"a":true}`),
@@ -574,10 +574,8 @@ func TestConnection_TypeMappingHandler(t *testing.T) {
 					}
 				},
 			},
-			want: nil,
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.EqualError(t, err, "no mapped type found for routing key 'unknown'")
-			},
+			want:    nil,
+			wantErr: assert.NoError,
 		},
 		{
 			name: "parse error",


### PR DESCRIPTION
This is needed if not all services should define all mappings. 😂 