### PR TITLE
BREAKING CHANGE: change signature of errorlog

### DIFF
--- a/connection_options.go
+++ b/connection_options.go
@@ -67,12 +67,12 @@ func CloseListener(e chan error) Setup {
 }
 
 // UseLogger allows an errorLogf to be used to log errors during processing of messages
-func UseLogger(logger errorLogf) Setup {
+func UseLogger(logger errorLog) Setup {
 	return func(c *Connection) error {
 		if logger == nil {
 			return ErrNilLogger
 		}
-		c.errorLogF = logger
+		c.errorLog = logger
 		return nil
 	}
 }

--- a/connection_options_test.go
+++ b/connection_options_test.go
@@ -36,16 +36,16 @@ import (
 )
 
 func Test_UseLogger(t *testing.T) {
-	conn := &Connection{errorLogF: nil}
+	conn := &Connection{errorLog: nil}
 	logger := noOpLogger
 	loggerName := runtime.FuncForPC(reflect.ValueOf(logger).Pointer()).Name()
 	require.NoError(t, UseLogger(logger)(conn))
-	setLoggerName := runtime.FuncForPC(reflect.ValueOf(conn.errorLogF).Pointer()).Name()
+	setLoggerName := runtime.FuncForPC(reflect.ValueOf(conn.errorLog).Pointer()).Name()
 	require.Equal(t, loggerName, setLoggerName)
 
-	conn = &Connection{errorLogF: nil}
+	conn = &Connection{errorLog: nil}
 	require.EqualError(t, UseLogger(nil)(conn), "cannot use nil as logger func")
-	require.Nil(t, conn.errorLogF)
+	require.Nil(t, conn.errorLog)
 }
 
 func Test_CloseListener(t *testing.T) {

--- a/connection_test.go
+++ b/connection_test.go
@@ -437,7 +437,7 @@ func Test_DivertToMessageHandler(t *testing.T) {
 		started:       true,
 		channel:       &channel,
 		messageLogger: noOpMessageLogger(),
-		errorLogF:     noOpLogger,
+		errorLog:      noOpLogger,
 	}
 	c.divertToMessageHandlers(queueDeliveries, handlers.Queues()[0].Handlers)
 
@@ -497,7 +497,7 @@ func testHandleMessage(json string, handle bool) MockAcknowledger {
 	}
 	c := &Connection{
 		messageLogger: noOpMessageLogger(),
-		errorLogF:     noOpLogger,
+		errorLog:      noOpLogger,
 	}
 	c.handleMessage(delivery, func(i any, headers Headers) (any, error) {
 		if handle {

--- a/logger.go
+++ b/logger.go
@@ -23,7 +23,7 @@
 package goamqp
 
 // errorLogf function called for error logs
-type errorLogf func(s string, a ...any)
+type errorLog func(s string)
 
 // noOpLogger log function that does nothing
-var noOpLogger = func(s string, a ...any) {}
+var noOpLogger = func(s string) {}


### PR DESCRIPTION
Since slog is incompatible with the old way of passing format and parameters we change this to just a string argument to be logged instead.