### PR TITLE
build(commitlint): update commitlint config to use .mjs format

### DIFF
--- a/.github/commitlint.config.mjs
+++ b/.github/commitlint.config.mjs
@@ -1,7 +1,5 @@
-const Configuration = {
-
+export default {
   extends: ['@commitlint/config-conventional'],
-
   /*
    * Any rules defined here will override rules from @commitlint/config-conventional
    */
@@ -9,5 +7,3 @@ const Configuration = {
     'body-max-line-length': [2, 'always', 200],
   },
 };
-
-module.exports = Configuration;

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -10,4 +10,4 @@ jobs:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6
         with:
-          configFile: "./.github/commitlint.config.js"
+          configFile: "./.github/commitlint.config.mjs"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,4 +35,5 @@ jobs:
           files: ./coverage.txt
           fail_ci_if_error: true
           flags: tests
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
Changed the commitlint config file to use the .mjs format for better
compatibility.