### PR TITLE
refactor(go): update Go version to 1.22.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sparetimecoders/goamqp
 
-go 1.21
+go 1.22.12
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Updates the Go toolchain version to 1.22.12 in the go.mod file. This 
ensures compatibility with the latest language features and security 
improvements, enhancing the overall stability and performance of the 
project.