### PR TITLE
fix: make queues exclusive in transient queue declarations

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -293,7 +293,7 @@ func transientQueueDeclare(channel AmqpChannel, name string) error {
 	_, err := channel.QueueDeclare(name,
 		false,
 		true,
-		false,
+		true,
 		false,
 		queueDeclareExpiration,
 	)

--- a/connection_options_test.go
+++ b/connection_options_test.go
@@ -424,7 +424,7 @@ func Test_TransientEventStreamConsumer_Ok(t *testing.T) {
 	require.Equal(t, ExchangeDeclaration{name: "events.topic.exchange", kind: "topic", durable: true, autoDelete: false, internal: false, noWait: false, args: amqp.Table{}}, channel.ExchangeDeclarations[0])
 
 	require.Equal(t, 1, len(channel.QueueDeclarations))
-	require.Equal(t, QueueDeclaration{name: "events.topic.exchange.queue.svc-00010203-0405-4607-8809-0a0b0c0d0e0f", durable: false, autoDelete: true, noWait: false, args: amqp.Table{"x-expires": 432000000}}, channel.QueueDeclarations[0])
+	require.Equal(t, QueueDeclaration{name: "events.topic.exchange.queue.svc-00010203-0405-4607-8809-0a0b0c0d0e0f", durable: false, autoDelete: true, exclusive: true, noWait: false, args: amqp.Table{"x-expires": 432000000}}, channel.QueueDeclarations[0])
 
 	require.Equal(t, 1, len(conn.queueHandlers.Queues()))
 	invoker, _ := conn.queueHandlers.Handlers("events.topic.exchange.queue.svc-00010203-0405-4607-8809-0a0b0c0d0e0f").Get("key")

--- a/connection_test.go
+++ b/connection_test.go
@@ -263,7 +263,7 @@ func Test_TransientQueueDeclare(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(channel.QueueDeclarations))
-	require.Equal(t, QueueDeclaration{name: "test", durable: false, autoDelete: true, noWait: false, args: amqp.Table{"x-expires": int(deleteQueueAfter.Seconds() * 1000)}}, channel.QueueDeclarations[0])
+	require.Equal(t, QueueDeclaration{name: "test", durable: false, autoDelete: true, exclusive: true, noWait: false, args: amqp.Table{"x-expires": int(deleteQueueAfter.Seconds() * 1000)}}, channel.QueueDeclarations[0])
 }
 
 func Test_ExchangeDeclare(t *testing.T) {

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -44,6 +44,7 @@ type QueueDeclaration struct {
 	name       string
 	durable    bool
 	autoDelete bool
+	exclusive  bool
 	noWait     bool
 	args       amqp.Table
 }
@@ -205,7 +206,7 @@ func (m *MockAmqpChannel) QueueDeclare(name string, durable, autoDelete, exclusi
 		return amqp.Queue{}, *m.QueueDeclarationError
 	}
 
-	m.QueueDeclarations = append(m.QueueDeclarations, QueueDeclaration{name, durable, autoDelete, noWait, args})
+	m.QueueDeclarations = append(m.QueueDeclarations, QueueDeclaration{name, durable, autoDelete, exclusive, noWait, args})
 	return amqp.Queue{}, nil
 }
 


### PR DESCRIPTION
Set the exclusive flag to true for transient queues in various locations, 
including queue declarations and test cases, to ensure that the queues are 
created for exclusive use by the connection. This change enhances 
resource management and prevents unintended access from other 
connections. Update the corresponding tests to align with the new 
queue declaration structure.