### PR TITLE
fix: add duplicate service publisher validation

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -101,6 +101,8 @@ var (
 	ErrNilLogger = errors.New("cannot use nil as logger func")
 	// ErrRecoverable will not be logged during message processing
 	ErrRecoverable = errors.New("recoverable error")
+	// ErrServicePublisherAlreadyExist is returned when a service publisher is already registered
+	ErrServicePublisherAlreadyExist = errors.New("service publisher already exists")
 )
 
 // NewFromURL creates a new Connection from an URL

--- a/connection_options.go
+++ b/connection_options.go
@@ -261,6 +261,9 @@ func ServiceRequestConsumer(routingKey string, handler HandlerFunc, eventType an
 // ServicePublisher sets up ap a publisher, that sends messages to the targetService
 func ServicePublisher(targetService string, publisher *Publisher) Setup {
 	return func(c *Connection) error {
+		if publisher.exchange != "" {
+			return ErrServicePublisherAlreadyExist
+		}
 		reqExchangeName := serviceRequestExchangeName(targetService)
 		publisher.connection = c
 		if err := publisher.setDefaultHeaders(c.serviceName); err != nil {

--- a/connection_options_test.go
+++ b/connection_options_test.go
@@ -408,6 +408,18 @@ func Test_ServicePublisher_ExchangeDeclareFail(t *testing.T) {
 	require.EqualError(t, err, e.Error())
 }
 
+func Test_ServicePublisher_DuplicateServicePublisher(t *testing.T) {
+	channel := NewMockAmqpChannel()
+	conn := mockConnection(channel)
+
+	p := NewPublisher()
+
+	err := ServicePublisher("svc", p)(conn)
+	require.NoError(t, err)
+	err = ServicePublisher("svc2", p)(conn)
+	require.EqualError(t, err, ErrServicePublisherAlreadyExist.Error())
+}
+
 func Test_TransientEventStreamConsumer_Ok(t *testing.T) {
 	channel := NewMockAmqpChannel()
 	conn := mockConnection(channel)


### PR DESCRIPTION
Introduce validation in ServicePublisher to prevent registering 
duplicate service publishers. Add a new error for this case and 
implement a test to ensure the functionality works as intended. 
These changes enhance the integrity of the publisher setup process.