### PR TITLE
chore: update actions for govulncheck and license-check

### DIFF
--- a/.github/workflows/govuln.yaml
+++ b/.github/workflows/govuln.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: opzkit/govulncheck-action@v1
+      - uses: opzkit/govulncheck-action@f522a4de778cf9f398be705615b86addf059f594 # v1.1.1
         with:
           go-version: 'stable'
           check-latest: true

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -10,7 +10,7 @@ jobs:
     name: License and Copyright Check
     steps:
       - uses: actions/checkout@v5
-      - uses: opzkit/go-license-check-action@v1
+      - uses: opzkit/go-license-check-action@54ae2868c816a22f8fae9027c38d06c14b37613a # v1.1.0
         with:
           go-version: 'stable'
           check-latest: true


### PR DESCRIPTION
Updates the govulncheck and go-license-check GitHub Actions to their  
latest versions. This ensures better compatibility and incorporates  
latest fixes and features, improving security and compliance checks.