### PR TITLE
chore: trim trailing newlines and prune stale go.sum entry

### DIFF
--- a/docs/message_processing.md
+++ b/docs/message_processing.md
@@ -44,4 +44,3 @@ If anything but `nil` is returned from `HandlerFunc` the message will be rejecte
 be processed again).
 
 If goamqp fails to unmarshal the JSON content in the message, the message will be rejected and **not** requeued again.
-

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -47,4 +47,3 @@ A service that is listening for incoming *responses* will consume messages from 
 ## References
 
 For full reference take a look at the [code](../naming.go) and [tests](../naming_test.go)
-


### PR DESCRIPTION
Pre-commit cleanups: remove trailing blank line from docs and drop superseded amqp091-go v1.10.0 entries from go.sum.
